### PR TITLE
 Backport VISITABLE_INIT on top of 1.0.0 

### DIFF
--- a/recipe/backport_visitable_init.patch
+++ b/recipe/backport_visitable_init.patch
@@ -1,0 +1,103 @@
+From c03870d80f01a779484dfd4cfc4e27e2772f164d Mon Sep 17 00:00:00 2001
+From: Chris Beck <chbeck@tesla.com>
+Date: Wed, 21 Mar 2018 13:23:30 -0700
+Subject: [PATCH 1/4] Update readme to mention C++14 support
+
+---
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/README.md b/README.md
+index 35eef8c..ad24f2b 100644
+--- a/README.md
++++ b/README.md
+@@ -4,7 +4,7 @@
+ [![Appveyor status](https://ci.appveyor.com/api/projects/status/6ksqg7es938cttn2/branch/master?svg=true)](https://ci.appveyor.com/project/cbeck88/visit_struct)
+ [![Boost licensed](https://img.shields.io/badge/license-Boost-blue.svg)](./LICENSE)
+ 
+-A header-only library providing **structure visitors** for C++11.
++A header-only library providing **structure visitors** for C++11 and C++14.
+ 
+ ## Motivation
+ 
+
+From 8c91d2283c7050593df5b692a13cb0ea99ba81d5 Mon Sep 17 00:00:00 2001
+From: Chris Beck <chbeck@tesla.com>
+Date: Fri, 30 Mar 2018 09:32:07 -0700
+Subject: [PATCH 2/4] README: "works with X.Y.Z" -> "is known to work with
+ X.Y.Z" compiler versions
+
+---
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/README.md b/README.md
+index ad24f2b..ac9e579 100644
+--- a/README.md
++++ b/README.md
+@@ -560,7 +560,7 @@ These limits can both be increased, see the source comments and also [IMPLEMENTA
+ **visit_struct** targets C++11 -- you need to have r-value references at least, and for the intrusive syntax, you need
+ variadic templates also.
+ 
+-**visit_struct** works with versions of gcc `>= 4.8.2` and versions of clang `>= 3.5`.
++**visit_struct** is known to work with versions of gcc `>= 4.8.2` and versions of clang `>= 3.5`.
+ 
+ The appveyor build tests against MSVC 2013, 2015, 2017.
+ 
+
+From 0e853f45f61e8b0fb714aa6c92ed53fc60dc0dbf Mon Sep 17 00:00:00 2001
+From: xenontrioxide <55810007+xenontrioxide@users.noreply.github.com>
+Date: Sun, 16 Jan 2022 03:02:47 -0700
+Subject: [PATCH 3/4] Fixes compile error from pull request #14
+
+Fixes VISITABLE_DIRECT_INIT from NikolausDemmel allowing users to direct initialize with an initializer list.
+---
+ .../visit_struct/visit_struct_intrusive.hpp   | 35 +++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/include/visit_struct/visit_struct_intrusive.hpp b/include/visit_struct/visit_struct_intrusive.hpp
+index fed65bd..a134cb9 100644
+--- a/include/visit_struct/visit_struct_intrusive.hpp
++++ b/include/visit_struct/visit_struct_intrusive.hpp
+@@ -382,6 +382,41 @@ static inline ::visit_struct::detail::Append_t<VISIT_STRUCT_GET_REGISTERED_MEMBE
+   Visit_Struct_Get_Visitables__(::visit_struct::detail::Rank<VISIT_STRUCT_GET_REGISTERED_MEMBERS::size + 1>);    \
+ static_assert(true, "")
+ 
++#define VISITABLE_INIT(TYPE, NAME, VALUE)                                                                        \
++TYPE NAME = VALUE;                                                                                               \
++struct VISIT_STRUCT_MAKE_MEMBER_NAME(NAME) :                                                                     \
++  visit_struct::detail::member_ptr_helper<VISIT_STRUCT_CURRENT_TYPE,                                             \
++                                          TYPE,                                                                  \
++                                          &VISIT_STRUCT_CURRENT_TYPE::NAME>                                      \
++{                                                                                                                \
++  static VISIT_STRUCT_CONSTEXPR const ::visit_struct::detail::char_array<sizeof(#NAME)> & member_name() {        \
++    return #NAME;                                                                                                \
++  }                                                                                                              \
++};                                                                                                               \
++static inline ::visit_struct::detail::Append_t<VISIT_STRUCT_GET_REGISTERED_MEMBERS,                              \
++                                               VISIT_STRUCT_MAKE_MEMBER_NAME(NAME)>                              \
++  Visit_Struct_Get_Visitables__(::visit_struct::detail::Rank<VISIT_STRUCT_GET_REGISTERED_MEMBERS::size + 1>);    \
++static_assert(true, "")
++
++#define VISITABLE_DIRECT_INIT(TYPE, NAME, ...)                                                                   \
++TYPE NAME __VA_ARGS__;                                                                                           \
++	struct VISIT_STRUCT_MAKE_MEMBER_NAME(NAME) :                                                                   \
++visit_struct::detail::member_ptr_helper<VISIT_STRUCT_CURRENT_TYPE,                                               \
++										TYPE,                                                                                        \
++										&VISIT_STRUCT_CURRENT_TYPE::NAME>                                                            \
++{                                                                                                                \
++	static VISIT_STRUCT_CONSTEXPR const ::visit_struct::detail::char_array<sizeof(#NAME)>& member_name()           \
++	{                                                                                                              \
++		return #NAME;                                                                                                \
++	}                                                                                                              \
++};                                                                                                               \
++static inline ::visit_struct::detail::Append_t<VISIT_STRUCT_GET_REGISTERED_MEMBERS,                              \
++											   VISIT_STRUCT_MAKE_MEMBER_NAME(NAME)>                                                    \
++	Visit_Struct_Get_Visitables__(::visit_struct::detail::Rank<VISIT_STRUCT_GET_REGISTERED_MEMBERS::size + 1>);    \
++static_assert(true, "")
++
++
++
+ #define END_VISITABLES                                                                                           \
+ typedef VISIT_STRUCT_GET_REGISTERED_MEMBERS Visit_Struct_Registered_Members_List__;                              \
+ typedef ::visit_struct::detail::intrusive_tag Visit_Struct_Visitable_Structure_Tag__;                            \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: 1.0.0.1
 
 source:
   url: https://github.com/garbageslam/visit_struct/archive/refs/tags/v{{ version }}.tar.gz


### PR DESCRIPTION
Upstream apparently is not going to make any new release soon (see https://github.com/garbageslam/visit_struct/issues/25). However, the only relevant new feature in master that downstream libraries use is the `VISITABLE_INIT` macro, without any modifications to existing macros, preventing any possible regressions for users of 1.0.0 . 

For this reason, in this PR I add the `VISITABLE_INIT` macro as an additional patch. I mark the version as 1.0.0.1, as the first three version numbers are left for upstream releases, while the last .1 indicate some changes. In this way, as soon as a new version upstream is released, we can just release it as `1.1`  or `1.0.1`, dropping the last `.1` .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
